### PR TITLE
Optional retrieving tag data from file info on missed Discogs info

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@
 
 ```
 
+### Possible options
+1. `--from-file-name` - enable retrieving tag data from filename if not found Discogs info. Notice: file with existing title tags won't be updated.
+
 
 
 

--- a/index.js
+++ b/index.js
@@ -8,6 +8,8 @@ var fix = require('./lib/fix');
 
 menu();
 
+setConsoleOptions();
+
 
 function menu(){
 
@@ -41,6 +43,16 @@ function menu(){
 			fix.fixMultiple();
 		}
 	});
+}
+
+function setConsoleOptions() {
+	const options = {};
+
+	if (process.argv.indexOf('--from-file-name') != -1) {
+		options.needFillTagsFromFileName = true;
+	}
+
+	fix.setSearchOptions(options);
 }
 
 function exit(){

--- a/lib/fix.js
+++ b/lib/fix.js
@@ -26,7 +26,10 @@ var currTags;
 
 var currMasterId;
 var currMasterRelease;
-var currSearchResult;
+var currSearchResult = {};
+
+let needFillTagsFromFileName = false;
+let hasTags = false;
 
 
 module.exports = {
@@ -55,7 +58,12 @@ module.exports = {
 			multipleFiles = files;
 			doFix(multipleFiles[multipleIndex]);
 		});
-	}	
+	},
+	setSearchOptions(options) {
+		if (options.hasOwnProperty('needFillTagsFromFileName')) {
+			needFillTagsFromFileName = true;
+		}
+	}
 };
 
 
@@ -74,23 +82,48 @@ function doFix(file){
 	}
 	else{
 		goNext();
-	}	
-}
+	}
 
-function searchResults(err, data){
-	if(data && data.results.length > 0){
-		currSearchResult = data.results[0];
-		if(currSearchResult.id){
-			currMasterId = currSearchResult.id;
-			var imgURL = currSearchResult.thumb || null;
-			getInformation();
+	function searchResults(err, data){
+		if(data && data.results && data.results.length > 0){
+			currSearchResult = data.results[0];
+			if(currSearchResult.id){
+				currMasterId = currSearchResult.id;
+				var imgURL = currSearchResult.thumb || null;
+				getInformation();
+			}
+			else{
+				noSearchDataFound();
+			}
 		}
 		else{
-			console.log(chalk.red('We could not find a master id for that song.'));
+			noSearchDataFound();
+		}
+
+		function noSearchDataFound() {
+			console.log(chalk.red('We could not find any data for that song.'));
+			if(needFillTagsFromFileName){
+				checkTitleInfo();
+			}
 		}
 	}
-	else{
-		console.log(chalk.red('We could not find any data for that song.'));
+
+	function checkTitleInfo() {
+		if(hasTags){
+			console.log(chalk.yellow('File ' + file + ' already has tags'));
+			goNext();
+		}
+		else{
+			console.log(chalk.yellow('Tag filled from filename' + file));
+			currSearchResult = {};
+			const parts = currID3.split(' - ');
+			currMasterRelease = {
+				artists: [{name: parts[1]}],
+				genres: [],
+				title: parts[0]
+			};
+			fillTags();
+		}
 	}
 }
 
@@ -119,7 +152,7 @@ function saveImage(err, masterRelease){
 
 
 function fillTags(err){
-	t = currMasterRelease;
+	const t = currMasterRelease;
 
 	if(err){
 		console.log(chalk.red(err));
@@ -208,6 +241,7 @@ function getCurrentID3(file){
 			return ENCODED_BY;
 		}
 		else if(tags.title){
+			hasTags = true;
 			return tags.title + ' - ' + tags.artist;
 		}
 	}
@@ -217,6 +251,7 @@ function getCurrentID3(file){
 }
 
 function goNext(){
+	hasTags = false;
 	if(isMultiple && multipleIndex+1 < multipleFiles.length ){
 		doFix(multipleFiles[++multipleIndex]);
 	}
@@ -240,5 +275,6 @@ function resetVariables(){
 	currTags = null;
 	currMasterId = null;
 	currMasterRelease = null;
-	currSearchResult = null;
+	currSearchResult = {};
+	hasTags = false;
 }


### PR DESCRIPTION
I've implemented optional retrieving tag data from filename if missed info in Discogs. It can be enabled by passing extra options in console.

Also before write data fetched  from filename I check has file tags or not. Sometimes it is filled, just Discogs has no info about files.